### PR TITLE
Add workers for parallel transformation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ dev.down:
 	docker-compose -p dev down -v
 
 .PHONY: build
-build: tests.docker
+build: verify
+	go build -v ./...
 
 .PHONY: verify
 verify:

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -99,28 +99,22 @@ func produceMessages(t *testing.T, messages []*confluent.Message) {
 	p.Flush(10000)
 }
 
-func assertEquals(t *testing.T, a, b []*confluent.Message) bool {
+func assertEquals(t *testing.T, a, b []*confluent.Message) {
 	if len(a) != len(b) {
-		t.Logf("messages length not equals, %v != %v", len(a), len(b))
-		return false
+		t.Fatalf("messages length not equals, %v != %v", len(a), len(b))
 	}
 
 	for i, msg := range a {
 		if !reflect.DeepEqual(msg.Headers, b[i].Headers) {
-			t.Logf("headers not equals, %v != %v", msg.Headers, b[i].Headers)
-			return false
+			t.Fatalf("headers not equals, %v != %v", msg.Headers, b[i].Headers)
 		}
 		if !bytes.Equal(msg.Key, b[i].Key) {
-			t.Logf("keys not equals, %v != %v", msg.Key, b[i].Key)
-			return false
+			t.Fatalf("keys not equals, %v != %v", msg.Key, b[i].Key)
 		}
 		if !bytes.Equal(msg.Value, b[i].Value) {
-			t.Logf("values not equals, %v != %v", msg.Value, b[i].Value)
-			return false
+			t.Fatalf("values not equals, %v != %v", msg.Value, b[i].Value)
 		}
 	}
-
-	return true
 }
 
 func consumeMessages(t *testing.T, topic string) []*confluent.Message {

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -7,7 +7,7 @@ import (
 	confluent "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 )
 
-func TestPassThroughTransformer(t *testing.T) {
+func TestTransformer_passthrough(t *testing.T) {
 	srcTopic := getTopic(t, "source-topic")
 	dstTopic := srcTopic + "-passthrough"
 
@@ -21,6 +21,7 @@ func TestPassThroughTransformer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer transformer.Stop()
 
 	go func() {
 		err = transformer.Run()
@@ -34,9 +35,43 @@ func TestPassThroughTransformer(t *testing.T) {
 
 	finalMessages := consumeMessages(t, dstTopic)
 
-	t.Logf("Final messages= %v", finalMessages)
+	assertEquals(t, messages, finalMessages)
+}
+
+func TestPassthrough_ordering_should_be_kept(t *testing.T) {
+	srcTopic := getTopic(t, "source-topic")
+	dstTopic := srcTopic + "-passthrough"
+
+	config := kafka.Config{
+		SourceTopic:    srcTopic,
+		ConsumerConfig: getConsumerConfig(t, "integration-test-group"),
+		ProducerConfig: getProducerConfig(),
+		BufferSize:     10,
+	}
+
+	transformer, err := kafka.NewKafkaTransformer(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer transformer.Stop()
+
+	go func() {
+		err = transformer.Run()
+	}()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// why 25 ? because 25 % 10 = 5 , so there will be remaining messages in the queue
+	messages := make([]*confluent.Message, 25)
+
+	for i := range messages {
+		messages[i] = message(srcTopic, "message"+string(i))
+	}
+
+	produceMessages(t, messages)
+
+	finalMessages := consumeMessages(t, dstTopic)
 
 	assertEquals(t, messages, finalMessages)
-
-	transformer.Stop()
 }

--- a/internal/transformer/workers.go
+++ b/internal/transformer/workers.go
@@ -1,0 +1,100 @@
+package transformer
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/etf1/kafka-transformer/pkg/logger"
+	pkg "github.com/etf1/kafka-transformer/pkg/transformer"
+	confluent "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+)
+
+// Workers is a pool of goroutines used for parallel transformation
+type Workers struct {
+	log logger.Log
+	// represents the input channel for transforming message
+	workChan chan *confluent.Message
+	// maxWorker is the maximum number of goroutines working together
+	maxWorker int
+	// transformer function to perform by a worker
+	transformer pkg.Transformer
+}
+
+func newWorkers(log logger.Log, maxWorker int, workChan chan *confluent.Message, transformer pkg.Transformer) Workers {
+	return Workers{
+		log:         log,
+		workChan:    workChan,
+		maxWorker:   maxWorker,
+		transformer: transformer,
+	}
+}
+
+func flushChunk(resultChan chan *confluent.Message, chunk []*confluent.Message, size int) {
+	for i := 0; i < size; i++ {
+		resultChan <- chunk[i]
+	}
+
+	for i := 0; i < len(chunk); i++ {
+		chunk[i] = nil
+	}
+}
+
+// Run starts parallel processing of messages
+func (w Workers) Run(resultChan chan *confluent.Message) {
+	log.Println("starting transformer workers")
+
+	wg := sync.WaitGroup{}
+	chunk := make([]*confluent.Message, w.maxWorker)
+	counter := 0
+
+loop:
+	for {
+		select {
+		case msg, ok := <-w.workChan:
+			if !ok {
+				w.log.Debugf("worker: channel closed, breaking the loop")
+				break loop
+			}
+			wg.Add(1)
+			go func(index int, msg *confluent.Message) {
+				defer wg.Done()
+				defer func() {
+					if err := recover(); err != nil {
+						w.log.Errorf("worker: a panic has occurred: %v", err)
+						chunk[index] = nil
+					}
+				}()
+				w.log.Debugf("worker: #%v, message received %v, working...", index, msg)
+				chunk[index] = w.transformer.Transform(msg)
+				w.log.Debugf("worker: #%v, work done %v", index, msg)
+			}(counter, msg)
+
+			counter++
+
+			if counter != 0 && counter%w.maxWorker == 0 {
+				w.log.Debugf("worker: waiting for %v goroutines to complete...", counter)
+				wg.Wait()
+				flushChunk(resultChan, chunk, counter)
+				counter = 0
+			}
+		case <-time.After(2 * time.Second):
+			w.log.Debugf("worker: nothing to do...")
+			if counter > 0 {
+				w.log.Debugf("worker: flushing remaining messages (length:%v)...", counter)
+				flushChunk(resultChan, chunk, counter)
+				counter = 0
+			}
+		}
+	}
+
+	w.log.Debugf("worker: waiting for last %v goroutines to complete...", counter)
+	wg.Wait()
+
+	if counter > 0 {
+		w.log.Debugf("worker: flushing last messages (length:%v)...", counter)
+		flushChunk(resultChan, chunk, counter)
+		counter = 0
+	}
+	log.Println("stopping transformer workers")
+}

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -15,7 +15,7 @@ import (
 // Config is the configuration used by KafkaTransformer
 type Config struct {
 	SourceTopic    string
-	bufferSize     int
+	BufferSize     int
 	ConsumerConfig *confluent.ConfigMap
 	ProducerConfig *confluent.ConfigMap
 	Transformer    transformer.Transformer
@@ -45,8 +45,8 @@ func NewKafkaTransformer(config Config) (Transformer, error) {
 	}
 
 	bufferSize := 200
-	if config.bufferSize != 0 {
-		bufferSize = config.bufferSize
+	if config.BufferSize != 0 {
+		bufferSize = config.BufferSize
 	}
 
 	consumer, err := kafka.NewConsumer(l, config.SourceTopic, config.ConsumerConfig, bufferSize)


### PR DESCRIPTION
With this change, a pool of goroutines will make transformation of messages in parallel.
The ordering of the messages will be kept.