### PR TITLE
Change Transformer interface

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/etf1/kafka-transformer/examples
 go 1.14
 
 require (
-	github.com/etf1/kafka-transformer v0.0.0-20200317113321-421200ff8b94
+	github.com/etf1/kafka-transformer v0.0.0-20200327090708-353621d904e9
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/influxdata/influxdb v1.7.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/etf1/kafka-transformer v0.0.0-20200317113321-421200ff8b94 h1:AoB+kVit8R65fttmu7fjZEnLbmSeR/NJFfAK9phDGGA=
 github.com/etf1/kafka-transformer v0.0.0-20200317113321-421200ff8b94/go.mod h1:fHmGpA5Hl2VxfdQaaFfdne+HotTzzCG5DoWTzLX3384=
 github.com/etf1/kafka-transformer v0.0.0-20200326091539-aadcff6a965a h1:V5ryLIv/MhsDXby2V0jvdbldRTp17UiPny+pi5/5O6Y=
+github.com/etf1/kafka-transformer v0.0.0-20200327090708-353621d904e9 h1:/pCg1Rht2I4tfAGcgXKV2RHTrzAboPJdkpkd8bXn++Y=
+github.com/etf1/kafka-transformer v0.0.0-20200327090708-353621d904e9/go.mod h1:fHmGpA5Hl2VxfdQaaFfdne+HotTzzCG5DoWTzLX3384=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-redis/redis v6.15.7+incompatible h1:3skhDh95XQMpnqeqNftPkQD9jL9e5e36z/1SUm6dy1U=
 github.com/go-redis/redis/v7 v7.2.0 h1:CrCexy/jYWZjW0AyVoHlcJUeZN19VWlbepTh1Vq6dJs=
@@ -34,6 +36,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/test/helper.go
+++ b/internal/test/helper.go
@@ -112,7 +112,17 @@ func assertEquals(t *testing.T, a, b []*confluent.Message) {
 			t.Fatalf("keys not equals, %v != %v", msg.Key, b[i].Key)
 		}
 		if !bytes.Equal(msg.Value, b[i].Value) {
-			t.Fatalf("values not equals, %v != %v", msg.Value, b[i].Value)
+			t.Fatalf("values not equals, %v != %v", string(msg.Value), string(b[i].Value))
+		}
+	}
+}
+
+func printMessages(t *testing.T, prefix string, msgs []*confluent.Message) {
+	for i, msg := range msgs {
+		if msg == nil {
+			t.Logf("%v: %v: message is nil\n", prefix, i)
+		} else {
+			t.Logf("%v: %v: value:%v\n", prefix, i, string(msg.Value))
 		}
 	}
 }
@@ -131,7 +141,7 @@ func consumeMessages(t *testing.T, topic string) []*confluent.Message {
 
 	stopChan := make(chan bool)
 	go func() {
-		time.Sleep(10 * time.Second)
+		time.Sleep(15 * time.Second)
 		stopChan <- true
 	}()
 

--- a/internal/test/transformer.go
+++ b/internal/test/transformer.go
@@ -9,17 +9,34 @@ type unstableTransformer struct {
 	passthrough transformer.Transformer
 }
 
-// NewUnstableTransformer will return a transformer panicking every modulo sequence
+// NewUnstableTransformer creates a transformer which will panic when a message is equal to "panic"
 func NewUnstableTransformer() transformer.Transformer {
 	return unstableTransformer{
 		passthrough: transformer.PassThrough(),
 	}
 }
 
-func (ut unstableTransformer) Transform(msg *kafka.Message) *kafka.Message {
+func (ut unstableTransformer) Transform(msg *kafka.Message) []*kafka.Message {
 	if string(msg.Value) == "panic" {
 		panic("dummy panic from unstable transformer")
 	}
 
 	return ut.passthrough.Transform(msg)
+}
+
+type duplicatorTransformer struct {
+	passthrough transformer.Transformer
+}
+
+// NewDuplicatorTransformer creates a transformer which will duplicate each message 1->2
+func NewDuplicatorTransformer() transformer.Transformer {
+	return duplicatorTransformer{
+		passthrough: transformer.PassThrough(),
+	}
+}
+
+func (dt duplicatorTransformer) Transform(msg *kafka.Message) []*kafka.Message {
+	result := dt.passthrough.Transform(msg)
+	// return 2 times the same message, for testing duplication
+	return append(result, result[0])
 }

--- a/internal/transformer/transformer.go
+++ b/internal/transformer/transformer.go
@@ -31,6 +31,7 @@ func (t *Transformer) Run(wg *sync.WaitGroup, inChan chan *confluent.Message) ch
 	workers := newWorkers(t.log, t.bufferSize, inChan, t.transformer)
 
 	go func() {
+		defer log.Println("transformer stopped")
 		defer wg.Done()
 		defer close(outChan)
 		defer log.Println("stopping transformer")

--- a/pkg/transformer/passthrough.go
+++ b/pkg/transformer/passthrough.go
@@ -7,7 +7,7 @@ import (
 type passThrough struct{}
 
 // Transform a kafka Message
-func (p passThrough) Transform(src *kafka.Message) *kafka.Message {
+func (p passThrough) Transform(src *kafka.Message) []*kafka.Message {
 	topic := *src.TopicPartition.Topic + "-passthrough"
 
 	msg := &kafka.Message{
@@ -20,7 +20,7 @@ func (p passThrough) Transform(src *kafka.Message) *kafka.Message {
 		Headers: src.Headers,
 	}
 
-	return msg
+	return []*kafka.Message{msg}
 }
 
 // PassThrough returns a transformer which does nothing,

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -8,5 +8,5 @@ import (
 // in order to transform a kafka Message.
 // If nil is returned the message will be ignored
 type Transformer interface {
-	Transform(src *kafka.Message) *kafka.Message
+	Transform(src *kafka.Message) []*kafka.Message
 }


### PR DESCRIPTION
Make the Transformer.Transform function returns an array instead of one message.
Why ? because sometimes you want to transform one message into multiple messages.